### PR TITLE
Updated express dependency to 3.21.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "daemon": "1.1.0",
     "date-format-lite": "0.5.0",
     "decl-api": "0.0.20",
-    "express": "3.4.7",
+    "express": "3.21.2",
     "fs.extra": "1.2.1",
     "gethub": "^2.0.1",
     "human-format": "^0.2.0",


### PR DESCRIPTION
I'm having problems with the express dependency in the current version (see http://forum.pimatic.org/topic/987/having-issues-with-asynchronous-operations). It seems that the current 3.x version doesn't have these problems anymore.