### PR TITLE
Assert getter exists

### DIFF
--- a/lib/devices.coffee
+++ b/lib/devices.coffee
@@ -132,6 +132,7 @@ module.exports = (env) ->
     getUpdatedAttributeValue: (attrName, arg) ->
       getter = 'get' + upperCaseFirst(attrName)
       # call the getter
+      assert @[getter]?, "Method #{getter} of #{@name} does not exist!"
       result = @[getter](arg)
       # Be sure that it is a promise!
       assert result.then?, "#{getter} of #{@name} should always return a promise!"


### PR DESCRIPTION
This helps during development as otherwise the missing getter only raises 

    TypeError: undefined is not a function