### PR TITLE
Added xAttributeOptions to DummyTemperatureSensor (correction)

### DIFF
--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -161,12 +161,12 @@ module.exports = {
   DummyTemperatureSensor:
     title: "DummyTemperatureSensor config options"
     type: "object"
-    extensions: ["xLink"]
+    extensions: ["xLink","xAttributeOptions"]
     properties: {}
   Timer:
     title: "timer config"
     type: "object"
-    extensions: ["xLink","xAttributeOptions"]
+    extensions: ["xLink"]
     properties: {
       resolution:
         description: "The interval the timer is updated in seconds"


### PR DESCRIPTION
Adds the ability to hide humidity in web frontend by adding the following to the device config

      "xAttributeOptions": [
        {
          "name": "humidity",
          "hidden": true
        }
      ]

(In the previous commit it went to Timer instead of DummyTemperatureSensor. :-/ )