### PR TITLE
Make DeviceConfigExtension available to other plugins

### DIFF
--- a/lib/devices.coffee
+++ b/lib/devices.coffee
@@ -1647,4 +1647,5 @@ module.exports = (env) ->
     DummyPresenceSensor
     DummyTemperatureSensor
     Timer
+    DeviceConfigExtension
   }


### PR DESCRIPTION
When developing a plugin, it's sometimes required to extend the config schema of devices, that don't belong to the plugin itself. 
For example pimatic-hap looks for a "hap" element of every supported device. This includes settings specific to this device but these settings are just interesting for pimatic-hap. Adding such an element to the config works, but pimatic logs an error message:
```
Invalid config of device "switch": Property "hap" is not a valid property
```
Although there is a concept to extend a devices config schema its not available to other plugins. 

This PR make the base class DeviceConfigExtension available to other plugins, so it's officially possible to extend a device config schema.  