### PR TITLE
Moving /usr/local/bin/ before /usr/bin/ in path as current raspberry …

### DIFF
--- a/install/pimatic-init-d
+++ b/install/pimatic-init-d
@@ -18,7 +18,7 @@
 # Make sure the pimatic.js file is linked in one of the pathes in the PATH variable below.
 # The node.js binary must be in the PATH, too.
 
-PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:/opt/node/bin
+PATH=/sbin:/usr/sbin:/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/opt/node/bin
 
 if [ "$1" = "start" ] || [ "$1" = "stop" ] || [ "$1" = "restart" ] || [ "$1" = "status" ] 
 then


### PR DESCRIPTION
…pi distributions come with an old node version in /usr/bin/ and thus pimatic will not start