### PR TITLE
Set PATH preference correct

### DIFF
--- a/install/pimatic-init-d
+++ b/install/pimatic-init-d
@@ -18,7 +18,7 @@
 # Make sure the pimatic.js file is linked in one of the pathes in the PATH variable below.
 # The node.js binary must be in the PATH, too.
 
-PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:/opt/node/bin
+PATH=/usr/local/bin:/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/sbin:/opt/node/bin
 
 if [ "$1" = "start" ] || [ "$1" = "stop" ] || [ "$1" = "restart" ] || [ "$1" = "status" ] 
 then


### PR DESCRIPTION
For pimatic 0.9 we need an updated node version which is installed in /usr/local/bin.
The pimatic service script uses the PATH statement PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:/opt/node/bin
This means that always the old 0.10 version is used in /usr/bin

For 0.9 the pimatic service script should contain the following PATH statement
PATH=/usr/local/bin:/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/sbin:/opt/node/bin

That has now been set with this patch