### PR TITLE
X-HTTP-Method-Override Support

### DIFF
--- a/lib/framework.coffee
+++ b/lib/framework.coffee
@@ -9,6 +9,7 @@ JaySchema = require 'jayschema'
 RJSON = require 'relaxed-json'
 i18n = require 'i18n'
 express = require "express"
+methodOverride = require 'method-override'
 connectTimeout = require 'connect-timeout'
 cookieParser = require 'cookie-parser'
 bodyParser = require 'body-parser'
@@ -236,6 +237,7 @@ module.exports = (env) ->
       # Setup express
       # -------------
       @app = express()
+      @app.use(methodOverride('X-HTTP-Method-Override'))
       @app.use(connectTimeout("5min", respond: false))
       extraHeaders = {}
       @corsEnabled = @config.settings.cors? and not _.isEmpty(@config.settings.cors.allowedOrigin)

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "knex": "^0.12.6",
     "lodash": "^3.10.1",
     "logrotate-stream": "^0.2.3",
+    "method-override": "^2.3.7",
     "moment": "^2.16.0",
     "npm": "^2.5.11",
     "relaxed-json": "^1.0.0",


### PR DESCRIPTION
Some HTTP clients (like HttpUrlConnection on Android) don't support all  request methods used by the Pimatic API. This patch enables the Express app of Pimatic to process requests via _POST_ and the _X-HTTP-Method-Override_ header field to support request methods not directly supported by the client implementation.

`...`
`connection.setRequestMethod("POST");`
`connection.setRequestProperty("X-HTTP-Method-Override", "PATCH");`
`...`