### PR TITLE
xButton device extension

### DIFF
--- a/lib/devices.coffee
+++ b/lib/devices.coffee
@@ -1198,6 +1198,15 @@ module.exports = (env) ->
 
     apply: (config, device) -> #should be handled by the frontend
 
+  class XButtonDeviceConfigExtension extends DeviceConfigExtension
+    configSchema:
+      xButton:
+        description: "Label for xButton device extension"
+        type: "string"
+        required: no
+
+    apply: (config, device) -> #should be handled by the frontend
+
   class PresentLabelConfigExtension extends DeviceConfigExtension
     configSchema:
       xPresentLabel:
@@ -1295,6 +1304,7 @@ module.exports = (env) ->
     constructor: (@framework, @devicesConfig) ->
       @deviceConfigExtensions.push(new ConfirmDeviceConfigExtention())
       @deviceConfigExtensions.push(new LinkDeviceConfigExtention())
+      @deviceConfigExtensions.push(new XButtonDeviceConfigExtension())
       @deviceConfigExtensions.push(new PresentLabelConfigExtension())
       @deviceConfigExtensions.push(new SwitchLabelConfigExtension())
       @deviceConfigExtensions.push(new ContactLabelConfigExtension())


### PR DESCRIPTION
![editdevice](https://cloud.githubusercontent.com/assets/4578458/22773049/59501c68-eea0-11e6-99dc-fa452ce703d6.png)

Thanks for the great pimatic framework. This PR is the backend part for the requested extension to pimatic-mobile-frontend [#21](https://github.com/pimatic/pimatic-mobile-frontend/pull/21). It provides the "xButton" device configuration option used by the mobile frontend to render dynamically generated javascript from the device action "xButton". It would be great to have this extension available for the core product. Thanks!