### PR TITLE
Run travis build with node 4, 8 and 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
-node_js:
-  - "4"
+matrix:
+  include:
+    - node_js: "4"
+    - node_js: "8"
+    - node_js: "10"
 before_install: ./install/travis-before-install
 before_script: ./install/travis-before-script

--- a/install/travis-before-install
+++ b/install/travis-before-install
@@ -6,3 +6,4 @@ mv pimatic node_modules/
 cd node_modules/pimatic
 pwd -P
 npm install sqlite3
+rm -f package-lock.json


### PR DESCRIPTION
It seems that pimatic runs with node 8 and 10 without any problems. This PR updates the .travis.yml to run the travis build with these versions, too. 