### PR TITLE
Cumulative of previous closed PR, and removing plugins with incompatible node ver from installable packages

### DIFF
--- a/lib/database.coffee
+++ b/lib/database.coffee
@@ -119,7 +119,7 @@ module.exports = (env) ->
       ).then( =>
         # Save log-messages
         @framework.on("messageLogged", @messageLoggedListener = ({level, msg, meta}) =>
-          if meta?.timeStamp and meta.tags?
+          if meta?.timestamp and meta.tags?
             @saveMessageEvent(meta.timestamp, level, meta.tags, msg).done()
         )
 

--- a/lib/devices.coffee
+++ b/lib/devices.coffee
@@ -743,11 +743,16 @@ module.exports = (env) ->
 
     _lastPressedButton: null
 
-    constructor: (@config)->
+    constructor: (@config, lastState)->
       @id = @config.id
       @name = @config.name
+      
       super()
-
+      
+      @_lastPressedButton = lastState?.button?.value
+      for button in @config.buttons
+        @_button = button if button.id is @_lastPressedButton
+    
     getButton: -> Promise.resolve(@_lastPressedButton)
 
     buttonPressed: (buttonId) ->

--- a/lib/plugins.coffee
+++ b/lib/plugins.coffee
@@ -39,6 +39,7 @@ module.exports = (env) ->
       if isCompatible(refVersion, value)
         versions.push key
     )
+    
     return versions
 
   getLatestCompatible = (packageInfo, refVersion) ->
@@ -265,7 +266,10 @@ module.exports = (env) ->
       unless pimaticRange
         return null
       return semver.satisfies(version, pimaticRange)
-
+    
+    getInstalledNode: () ->
+      return "#{process.versions.node}"
+    
     searchForPluginsWithInfo: ->
       return @searchForPlugin().then( (plugins) =>
         return pluginList = (
@@ -302,10 +306,10 @@ module.exports = (env) ->
       )
 
     getOutdatedPlugins: ->
-      return @getInstalledPluginUpdateVersions().then( (result) =>
+      @getInstalledPluginUpdateVersions().then( (result) =>
         outdated = []
         for p in result
-          if semver.gt(p.latest, p.current)
+          if semver.gt(p.latest, p.current) and semver.satisfies(@getInstalledNode(), p.node)
             outdated.push p
         return outdated
       )
@@ -322,6 +326,7 @@ module.exports = (env) ->
                 plugin: p
                 current: installed.version
                 latest: latest.version
+                node: latest.engines.node
               }
             )
         return Promise.settle(waiting).then( (results) =>

--- a/lib/plugins.coffee
+++ b/lib/plugins.coffee
@@ -306,7 +306,7 @@ module.exports = (env) ->
       )
 
     getOutdatedPlugins: ->
-      @getInstalledPluginUpdateVersions().then( (result) =>
+      return @getInstalledPluginUpdateVersions().then( (result) =>
         outdated = []
         for p in result
           if semver.gt(p.latest, p.current) and semver.satisfies(@getInstalledNode(), p.node)

--- a/lib/plugins.coffee
+++ b/lib/plugins.coffee
@@ -221,7 +221,6 @@ module.exports = (env) ->
           json.sort( (a, b) => a.name.localeCompare(b.name) )
           # cache for 1min
           setTimeout( (=> @_pluginList = null), 60*1000)
-          console.log(json)
           return json
         ).catch( (err) =>
           # cache errors only for 1 sec


### PR DESCRIPTION
Cumulative of:
- lastButtonPressed fix
- Hide plugins with higher node requirement than installed as upgrade candidate in "Updates"
- Hide plugins with higher node requirement than installed as installation candidate in "Plugins"-> "Browse Plugins"
- The latter two should also work when called via REST API