### PR TITLE
[pimatic] install specific version of plugin #1139

### DIFF
--- a/test/lib-plugins-test.coffee
+++ b/test/lib-plugins-test.coffee
@@ -12,6 +12,9 @@ describe "PluginManager", ->
 
   frameworkDummy =
     maindir: "#{os.tmpdir()}/pimatic-test/node_modules/pimatic"
+    packageJson: {
+      version: '0.9.53'
+    }
 
   pluginManager = null
   skip = not process.env['NPM_TESTS']
@@ -19,25 +22,23 @@ describe "PluginManager", ->
   before ->
     # make the temp dir:
     fs.mkdirpSync frameworkDummy.maindir
+    pluginManager = new env.plugins.PluginManager frameworkDummy
 
   after ->
     # make the temp dir:
     fs.rmrfSync "#{os.tmpdir()}/pimatic-test"
 
-  describe '#construct()', ->
-
-    it 'should construct the PluginManager', ->
-      pluginManager = new env.plugins.PluginManager frameworkDummy
-
   describe '#pathToPlugin()', ->
-
     it "should return #{os.tmpdir()}/pimatic-test/node_modules/pimatic-test", ->
       pluginPath = pluginManager.pathToPlugin('pimatic-test')
       assert pluginPath is path.normalize "#{os.tmpdir()}/pimatic-test/node_modules/pimatic-test"
 
-  describe '#installPlugin()', ->
+    it "should return #{os.tmpdir()}/pimatic-test/node_modules/pimatic-test for specific version", ->
+      pluginPath = pluginManager.pathToPlugin('pimatic-test@0.1.2')
+      assert pluginPath is path.normalize "#{os.tmpdir()}/pimatic-test/node_modules/pimatic-test"
 
-    it 'should install the plugin from npm',  unless skip then (finish) ->
+  describe '#installPlugin()', ->
+    it 'should install the plugin from npm', unless skip then (finish) ->
       this.timeout 20000
       pluginManager.installPlugin('pimatic-cron').then( ->
         assert fs.existsSync "#{os.tmpdir()}/pimatic-test/node_modules/pimatic-cron"
@@ -45,7 +46,7 @@ describe "PluginManager", ->
         finish()
       ).done()
 
-    it 'should install the plugin dependencies',  unless skip then (finish) ->
+    it 'should install the plugin dependencies', unless skip then (finish) ->
       this.timeout 20000
       fs.rmrfSync "#{os.tmpdir()}/pimatic-test/node_modules/pimatic-cron/node_modules"
       pluginManager.installPlugin('pimatic-cron').then( ->
@@ -53,30 +54,47 @@ describe "PluginManager", ->
         finish()
       ).done()
 
-  describe '#getInstalledPlugins()', ->
+    it 'should install a specific plugin version', unless skip then (finish) ->
+      this.timeout 20000
+      fs.rmrfSync "#{os.tmpdir()}/pimatic-test/node_modules/pimatic-cron"
+      pluginManager.installPlugin('pimatic-cron@0.8.7').then( ->
+        assert fs.existsSync "#{os.tmpdir()}/pimatic-test/node_modules/pimatic-cron"
+        packageJson = pluginManager.getInstalledPackageInfo('pimatic-cron')
+        asser packageJson.version is '0.8.7'
+        finish()
+      ).done()
 
-    it 'should return the pimatic-cron plugin',  unless skip then (finish) ->
-      pluginManager.getInstalledPlugins().then( (names) ->
+
+  describe '#getInstalledPlugins()', ->
+    it 'should return the pimatic-cron plugin', unless skip then (finish) ->
+      pluginManager.getInstalledPlugins().then((names) ->
         assert names.length is 1
         assert names[0] is 'pimatic-cron'
         finish()
       ).done()
 
   describe '#getInstalledPackageInfo()', ->
-
-    it 'should return pimatic-crons package.json',  unless skip then  ->
+    it 'should return pimatic-crons package.json', unless skip then  ->
       pkgInfo = pluginManager.getInstalledPackageInfo('pimatic-cron')
-      assert pkgInfo.name is 'pimatic-cron' 
+      assert pkgInfo.name is 'pimatic-cron'
 
   describe '#getNpmInfo()', ->
-
     it 'should return pimatic package info from the registry', (done) ->
       promise = pluginManager.getNpmInfo('pimatic')
-      promise.then( (pkgInfo) ->
+      promise.then((pkgInfo) ->
         console.log "-----", pkgInfo.name is "pimatic"
         assert pkgInfo.name is "pimatic"
         done()
       ).catch(done)
       return
 
- configFile = "#{os.tmpdir()}/pimatic-test-config.json"
+  describe '#extractPluginName()', ->
+    it 'should remove version info from name', ->
+      name = pluginManager.extractPluginName('pimatic-cron@0.8.7')
+      assert name is 'pimatic-cron'
+
+    it 'should return name if no version', ->
+      name = pluginManager.extractPluginName('pimatic-cron')
+      assert name is 'pimatic-cron'
+
+  configFile = "#{os.tmpdir()}/pimatic-test-config.json"

--- a/test/lib-plugins-test.coffee
+++ b/test/lib-plugins-test.coffee
@@ -29,11 +29,11 @@ describe "PluginManager", ->
     fs.rmrfSync "#{os.tmpdir()}/pimatic-test"
 
   describe '#pathToPlugin()', ->
-    it "should return #{os.tmpdir()}/pimatic-test/node_modules/pimatic-test", ->
+    it "should return path to plugin", ->
       pluginPath = pluginManager.pathToPlugin('pimatic-test')
       assert pluginPath is path.normalize "#{os.tmpdir()}/pimatic-test/node_modules/pimatic-test"
 
-    it "should return #{os.tmpdir()}/pimatic-test/node_modules/pimatic-test for specific version", ->
+    it "should return path to plugin for specific version", ->
       pluginPath = pluginManager.pathToPlugin('pimatic-test@0.1.2')
       assert pluginPath is path.normalize "#{os.tmpdir()}/pimatic-test/node_modules/pimatic-test"
 


### PR DESCRIPTION
This PR adds the possibility to set a specific version for plugins to be installed. When updating these plugins won't be updated as they will never get outdated. 
This feature is for people that are stuck with a specific version, because of incompatible changes in newer versions. This way it's possible to backup your config.json and always get the same setup. 