### PR TITLE
dependencies of grunt > 1.0.x are incompatible with node 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   "devDependencies": {
     "blanket": "^1.2.2",
     "coffee-errors": "^0.8.6",
-    "grunt": "^1.0.1",
+    "grunt": "~1.0.4",
     "grunt-bump": "0.8.0",
     "grunt-cli": "^1.2.0",
     "grunt-coffeelint": "^0.0.16",

--- a/test/pimatic-test.coffee
+++ b/test/pimatic-test.coffee
@@ -6,10 +6,8 @@ describe "pimatic", ->
     settings:
       locale: "en"
       authentication:
-        username: "test"
-        password: "test"
         enabled: true
-        disabled: true
+        secret: "secr3t"
       logLevel: "error"
       httpServer:
         enabled: true
@@ -21,9 +19,16 @@ describe "pimatic", ->
         connection: {
           filename: ':memory:'
         }
-      plugins: []
-      devices: []
-      rules: []
+    users: [
+      {
+        username: "test"
+        password: "test"
+        role: "admin"
+      }
+    ]
+    plugins: []
+    devices: []
+    rules: []
 
   fs = require 'fs'
   os = require 'os'


### PR DESCRIPTION
This PR only allows only minor updates of grunt (~1.0.4), because grunt from version 1.1.x breaks compatibility with node 4