### PR TITLE
Added predicates for AVPlayer device

### DIFF
--- a/lib/framework.coffee
+++ b/lib/framework.coffee
@@ -876,6 +876,7 @@ module.exports = (env) ->
           env.predicates.ButtonPredicateProvider
           env.predicates.DeviceAttributeWatchdogProvider
           env.predicates.StartupPredicateProvider
+          env.predicates.AVPlayerPredicateProvider
         ]
         for predProv in defaultPredicateProvider
           predProvInst = new predProv(this)


### PR DESCRIPTION
This corresponds with the PR on Pimatic-Kodi. These should go in together in order not to break installations where pimatic-kodi is active.